### PR TITLE
Large files and multiple file uploads/downloads do not work because TransferManager is GC'ed.

### DIFF
--- a/src/main/groovy/com/mgd/core/gradle/S3Plugin.groovy
+++ b/src/main/groovy/com/mgd/core/gradle/S3Plugin.groovy
@@ -10,6 +10,7 @@ import com.amazonaws.event.ProgressListener
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.transfer.Transfer
+import com.amazonaws.services.s3.transfer.TransferManager
 import com.amazonaws.services.s3.transfer.TransferManagerBuilder
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
@@ -167,35 +168,36 @@ class S3Download extends S3Task {
             throw new GradleException('Invalid parameters: [bucket] was not provided and/or a default was not set')
         }
 
-        // directory download
-        if (keyPrefix && destDir) {
-            if (key || file) {
-                throw new GradleException('Invalid parameters: [key, file] are not valid for S3 Download recursive')
+        TransferManager manager = TransferManagerBuilder.newInstance().withS3Client(s3Client).build()
+        try {
+            // directory download
+            if (keyPrefix && destDir) {
+                if (key || file) {
+                    throw new GradleException('Invalid parameters: [key, file] are not valid for S3 Download recursive')
+                }
+                logger.quiet("S3 Download recursive s3://${bucket}/${keyPrefix} → ${project.file(destDir)}/")
+                transfer = manager.downloadDirectory(bucket, keyPrefix, project.file(destDir))
             }
-            logger.quiet("S3 Download recursive s3://${bucket}/${keyPrefix} → ${project.file(destDir)}/")
-            transfer = TransferManagerBuilder.newInstance().withS3Client(s3Client).build()
-                            .downloadDirectory(bucket, keyPrefix, project.file(destDir))
-        }
 
-        // single file download
-        else if (key && file) {
-            if (keyPrefix || destDir) {
-                throw new GradleException('Invalid parameters: [keyPrefix, destDir] are not valid for S3 Download single file')
+            // single file download
+            else if (key && file) {
+                if (keyPrefix || destDir) {
+                    throw new GradleException('Invalid parameters: [keyPrefix, destDir] are not valid for S3 Download single file')
+                }
+                logger.quiet("S3 Download s3://${bucket}/${key} → ${file}")
+                File f = new File(file)
+                f.parentFile.mkdirs()
+                transfer = manager.download(bucket, key, f)
+            } else {
+                throw new GradleException('Invalid parameters: one of [key, file] or [keyPrefix, destDir] pairs must be specified for S3 Download')
             }
-            logger.quiet("S3 Download s3://${bucket}/${key} → ${file}")
-            File f = new File(file)
-            f.parentFile.mkdirs()
-            transfer = TransferManagerBuilder.newInstance().withS3Client(s3Client).build()
-                            .download(bucket, key, f)
-        }
 
-        else {
-            throw new GradleException('Invalid parameters: one of [key, file] or [keyPrefix, destDir] pairs must be specified for S3 Download')
+            def listener = new S3Listener(transfer, logger)
+            transfer.addProgressListener(listener)
+            transfer.waitForCompletion()
+        } finally {
+            manager.shutdownNow()
         }
-
-        def listener = new S3Listener(transfer, logger)
-        transfer.addProgressListener(listener)
-        transfer.waitForCompletion()
     }
 }
 


### PR DESCRIPTION
You have to keep a reference to the TransferManager while your transfers are happening or else it will be GC'ed causing all transfers to be interrupted. This now stores off that reference and then shuts it down in a finally block after the waitForCompletion() returns.

This fixes 2 issues. One is that large files would be truncated because the TransferManager kills then when it's GC'ed. And it also fixes a RejectedException being thrown while trying to download more files than there are background jobs and the TransferManager gets GC'ed in the middle of it. Both of these scenarios make it more likely that the TransferManager would be GC'ed causes the different issues.