### PR TITLE
Request to combine the work from fork

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016 Michael Keirnan
+Copyright (c) 2021 Charlie Hubbard
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Gradle S3 Plugin
 [![Install](https://img.shields.io/badge/install-plugin-brown.svg)](https://plugins.gradle.org/plugin/com.fuseanalytics.gradle.s3)
 [![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE)
-[![Gradle Plugin](https://img.shields.io/maven-metadata/v/https/plugins.gradle.org/m2/com/fuseanalytics/gradle/s3/com.fuseanalytics.gradle.s3.gradle.plugin/maven-metadata.xml.svg?label=gradle)](Gradle Plugin Version)
+[![Gradle Plugin](https://img.shields.io/maven-metadata/v/https/plugins.gradle.org/m2/com/fuseanalytics/gradle/s3/com.fuseanalytics.gradle.s3.gradle.plugin/maven-metadata.xml.svg?label=gradle)](https://plugins.gradle.org/plugin/com.fuseanalytics.gradle.s3)
 
 Simple Gradle plugin that uploads and downloads S3 objects. This is a fork of 
 the [gradle-s3-plugin](https://github.com/mygrocerydeals/gradle-s3-plugin) which 

--- a/README.md
+++ b/README.md
@@ -94,16 +94,22 @@ download and recursive download. Properties that apply to both modes:
 
   + `bucket` - S3 bucket to use *(optional, defaults to the project `s3` configured bucket)*
 
-For a single file download:
+For a single file download (deprecated - use keys parameter instead):
 
   + `key` - key of S3 object to download
   + `file` - local path of file to save the download to
   + `then` - *(optional)*, callback closure called upon completion with the java.io.File that was downloaded.
 
-For a recursive download:
+For a recursive download (deprecated - use keys parameter instead):
 
   + `keyPrefix` - S3 prefix of objects to download
   + `destDir` - local directory to download objects to
+  + `then` - *(optional)*, callback closure called upon completion with each java.io.File that was downloaded.
+
+For multiple download:
+  + `keys` - an Iterable of an individual file(s), key prefix ending with an asteriks (ie /dir1/dir2/logs*), 
+    or a whole directory (ie /dir1/).  Directories MUST end in a trailing forward slash (ie /)
+  + `destDir` - local directory to download objects into
   + `then` - *(optional)*, callback closure called upon completion with each java.io.File that was downloaded.
 
 ***Note***:  

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the following to your build.gradle file:
 
 ```groovy
 plugins {
-  id 'com.fuseanalytics.gradle.s3' version '1.1.3'
+  id 'com.fuseanalytics.gradle.s3' version '1.2.0'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the following to your build.gradle file:
 
 ```groovy
 plugins {
-  id 'com.fuseanalytics.gradle.s3' version '1.2.0'
+  id 'com.fuseanalytics.gradle.s3' version '1.2.1'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add the following to your build.gradle file:
 
 ```groovy
 plugins {
-  id 'com.fuseanalytics.gradle.s3' version '1.1.0'
+  id 'com.fuseanalytics.gradle.s3' version '1.1.2'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the following to your build.gradle file:
 
 ```groovy
 plugins {
-  id 'com.fuseanalytics.gradle.s3' version '1.2.1'
+  id 'com.fuseanalytics.gradle.s3' version '1.2.3'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,11 @@
 [![Install](https://img.shields.io/badge/install-plugin-brown.svg)](https://plugins.gradle.org/plugin/com.github.mgk.gradle.s3)
 [![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE)
 
-Simple Gradle plugin that uploads and downloads S3 objects. This is a fork of the [mgk/s3-plugin](https://github.com/mgk/s3-plugin), which no longer appears to be under active development.
-It has been updated to work with Gradle version 6 and later.
+Simple Gradle plugin that uploads and downloads S3 objects. This is a fork of 
+the [gradle-s3-plugin](https://github.com/mygrocerydeals/gradle-s3-plugin) which 
+is a fork of [mgk/s3-plugin](https://github.com/mgk/s3-plugin), which both  
+appear to be no longer under active development.  It has been updated to work with 
+Gradle version 6 and later.
 
 ## Setup
 
@@ -11,7 +14,7 @@ Add the following to your build.gradle file:
 
 ```groovy
 plugins {
-  id 'com.mgd.core.gradle.s3' version '1.1.0'
+  id 'com.fuseanalytics.gradle.s3' version '1.1.0'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -94,13 +94,13 @@ download and recursive download. Properties that apply to both modes:
 
   + `bucket` - S3 bucket to use *(optional, defaults to the project `s3` configured bucket)*
 
-For a single file download (deprecated - use keys parameter instead):
+~~For a single file download~~ (deprecated - use keys parameter instead):
 
   + `key` - key of S3 object to download
   + `file` - local path of file to save the download to
   + `then` - *(optional)*, callback closure called upon completion with the java.io.File that was downloaded.
 
-For a recursive download (deprecated - use keys parameter instead):
+~~For a recursive download~~ (deprecated - use keys parameter instead):
 
   + `keyPrefix` - S3 prefix of objects to download
   + `destDir` - local directory to download objects to

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Gradle S3 Plugin
-[![Install](https://img.shields.io/badge/install-plugin-brown.svg)](https://plugins.gradle.org/plugin/com.github.mgk.gradle.s3)
+[![Install](https://img.shields.io/badge/install-plugin-brown.svg)](https://plugins.gradle.org/plugin/com.fuseanalytics.gradle.s3)
 [![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE)
+[![Gradle Plugin](https://img.shields.io/maven-metadata/v/https/plugins.gradle.org/m2/com/fuseanalytics/gradle/s3/com.fuseanalytics.gradle.s3/maven-metadata.xml.svg?label=gradle)](Gradle Plugin Version)
 
 Simple Gradle plugin that uploads and downloads S3 objects. This is a fork of 
 the [gradle-s3-plugin](https://github.com/mygrocerydeals/gradle-s3-plugin) which 
@@ -14,7 +15,7 @@ Add the following to your build.gradle file:
 
 ```groovy
 plugins {
-  id 'com.fuseanalytics.gradle.s3' version '1.1.2'
+  id 'com.fuseanalytics.gradle.s3' version '1.1.3'
 }
 ```
 
@@ -74,6 +75,7 @@ For a single file upload:
   + `key` - key of S3 object to create
   + `file` - path of file to be uploaded
   + `overwrite` - *(optional, default is `false`)*, if `true` the S3 object is created or overwritten if it already exists.
+  + `then` - *(optional)*, callback closure called upon completion with the java.io.File that was uploaded.
 
 By default `S3Upload` does not overwrite the S3 object if it already exists. Set `overwrite` to `true` to upload the file even if it exists.
 
@@ -81,6 +83,7 @@ For a directory upload:
 
   + `keyPrefix` - root S3 prefix under which to create the uploaded contents
   + `sourceDir` - local directory containing the contents to be uploaded
+  + `then` - *(optional)*, callback closure called upon completion with each java.io.File that was uploaded.
 
 A directory upload will always overwrite existing content if it already exists under the specified S3 prefix.
 
@@ -95,11 +98,13 @@ For a single file download:
 
   + `key` - key of S3 object to download
   + `file` - local path of file to save the download to
+  + `then` - *(optional)*, callback closure called upon completion with the java.io.File that was downloaded.
 
 For a recursive download:
 
   + `keyPrefix` - S3 prefix of objects to download
   + `destDir` - local directory to download objects to
+  + `then` - *(optional)*, callback closure called upon completion with each java.io.File that was downloaded.
 
 ***Note***:  
   
@@ -117,6 +122,9 @@ a recursive download:
 task downloadRecursive(type: S3Download) {
   keyPrefix = 'top/foo/'
   destDir = 'local-dir'
+  then = { File file ->
+      // do something with the file
+  }  
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Gradle S3 Plugin
 [![Install](https://img.shields.io/badge/install-plugin-brown.svg)](https://plugins.gradle.org/plugin/com.fuseanalytics.gradle.s3)
 [![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE)
-[![Gradle Plugin](https://img.shields.io/maven-metadata/v/https/plugins.gradle.org/m2/com/fuseanalytics/gradle/s3/com.fuseanalytics.gradle.s3/maven-metadata.xml.svg?label=gradle)](Gradle Plugin Version)
+[![Gradle Plugin](https://img.shields.io/maven-metadata/v/https/plugins.gradle.org/m2/com/fuseanalytics/gradle/s3/com.fuseanalytics.gradle.s3.gradle.plugin/maven-metadata.xml.svg?label=gradle)](Gradle Plugin Version)
 
 Simple Gradle plugin that uploads and downloads S3 objects. This is a fork of 
 the [gradle-s3-plugin](https://github.com/mygrocerydeals/gradle-s3-plugin) which 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ wrapper {
 }
 
 group = 'com.fuseanalytics'
-version = '1.1.3'
+version = '1.2.0'
 
 jar {
     manifest {

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ wrapper {
 }
 
 group = 'com.fuseanalytics'
-version = '1.2.0'
+version = '1.2.1'
 
 jar {
     manifest {

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ wrapper {
 }
 
 group = 'com.fuseanalytics'
-version = '1.1.2'
+version = '1.1.3'
 
 jar {
     manifest {
@@ -26,7 +26,7 @@ repositories {
 }
 
 ext {
-    amazonAWSVersion = '1.11.734'
+    amazonAWSVersion = '1.11.1024'
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java-gradle-plugin'
-    id 'com.gradle.plugin-publish' version '0.10.1'
+    id 'com.gradle.plugin-publish' version '0.12.0'
     id 'idea'
     id 'groovy'
 }
@@ -9,8 +9,8 @@ wrapper {
     gradleVersion = '6.2.2'
 }
 
-group = 'com.mgd.core'
-version = '1.1.0'
+group = 'com.fuseanalytics'
+version = '1.1.1'
 
 jar {
     manifest {
@@ -38,16 +38,19 @@ dependencies {
 gradlePlugin {
     plugins {
         s3Plugin {
-            id = 'com.mgd.core.gradle.s3'
+            id = 'com.fuseanalytics.gradle.s3'
             displayName = 'Gradle S3 Plugin'
-            description = 'Lightweight S3 upload and download plugin'
-            implementationClass = 'com.mgd.core.gradle.S3Plugin'
+            description = """
+                             Lightweight S3 upload and download plugin 
+                             that supports single and multiple file 
+                             uploads/downloads"""
+            implementationClass = 'com.fuseanalytics.gradle.s3.S3Plugin'
         }
     }
 }
 
 pluginBundle {
-    website = 'https://github.com/mygrocerydeals/gradle-s3-plugin/blob/master/README.md'
-    vcsUrl = 'https://github.com/mygrocerydeals/gradle-s3-plugin'
+    website = 'https://github.com/chubbard/gradle-s3-plugin/blob/master/README.md'
+    vcsUrl = 'https://github.com/chubbard/gradle-s3-plugin'
     tags = ['aws', 's3']
 }

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ wrapper {
 }
 
 group = 'com.fuseanalytics'
-version = '1.2.1'
+version = '1.2.2'
 
 jar {
     manifest {
@@ -26,7 +26,7 @@ repositories {
 }
 
 ext {
-    amazonAWSVersion = '1.11.1024'
+    amazonAWSVersion = '1.12.334'
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ wrapper {
 }
 
 group = 'com.fuseanalytics'
-version = '1.2.2'
+version = '1.2.3'
 
 jar {
     manifest {

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ wrapper {
 }
 
 group = 'com.fuseanalytics'
-version = '1.1.1'
+version = '1.1.2'
 
 jar {
     manifest {

--- a/src/main/groovy/com/fuseanalytics/gradle/s3/AfterDownloadListener.groovy
+++ b/src/main/groovy/com/fuseanalytics/gradle/s3/AfterDownloadListener.groovy
@@ -1,0 +1,26 @@
+package com.fuseanalytics.gradle.s3
+
+import com.amazonaws.event.ProgressEvent
+import com.amazonaws.event.ProgressEventType
+import com.amazonaws.event.ProgressListener
+import com.amazonaws.services.s3.transfer.Download
+
+class AfterDownloadListener implements ProgressListener {
+
+    Download download
+    File dest
+    Closure<Void> then
+
+    AfterDownloadListener(Download download, File dest, Closure<Void> then) {
+        this.download = download
+        this.dest = dest
+        this.then = then
+    }
+
+    @Override
+    void progressChanged(ProgressEvent e) {
+        if( e.eventType == ProgressEventType.TRANSFER_COMPLETED_EVENT) {
+            then?.call( new File( dest, download.key ) )
+        }
+    }
+}

--- a/src/main/groovy/com/fuseanalytics/gradle/s3/AfterUploadListener.groovy
+++ b/src/main/groovy/com/fuseanalytics/gradle/s3/AfterUploadListener.groovy
@@ -1,0 +1,28 @@
+package com.fuseanalytics.gradle.s3
+
+import com.amazonaws.event.ProgressEventType
+import com.amazonaws.services.s3.transfer.Upload
+import com.amazonaws.event.ProgressEvent
+import com.amazonaws.event.ProgressListener
+import com.amazonaws.services.s3.transfer.model.UploadResult
+
+class AfterUploadListener implements ProgressListener {
+
+    Upload upload
+    File dest
+    Closure<Void> then
+
+    AfterUploadListener(Upload upload, File dest, Closure<Void> then) {
+        this.upload = upload
+        this.dest = dest
+        this.then = then
+    }
+
+    void progressChanged(ProgressEvent e) {
+        if( e.eventType == ProgressEventType.TRANSFER_COMPLETED_EVENT) {
+            UploadResult result = upload.waitForUploadResult()
+            then?.call( new File( dest, result.key ) )
+        }
+    }
+
+}

--- a/src/main/groovy/com/fuseanalytics/gradle/s3/S3Plugin.groovy
+++ b/src/main/groovy/com/fuseanalytics/gradle/s3/S3Plugin.groovy
@@ -40,7 +40,6 @@ abstract class S3Task extends DefaultTask {
     @Input
     String bucket
 
-    @Optional
     @Internal
     Closure<Void> then
 

--- a/src/main/groovy/com/fuseanalytics/gradle/s3/S3Plugin.groovy
+++ b/src/main/groovy/com/fuseanalytics/gradle/s3/S3Plugin.groovy
@@ -141,7 +141,8 @@ class S3Upload extends S3Task {
                         logger.quiet("S3 Upload ${file} → s3://${bucket}/${key} with overwrite")
                         up = manager.upload(bucket, key, new File(file))
                     } else {
-                        logger.quiet("s3://${bucket}/${key} exists, not overwriting")
+                        logger.error("s3://${bucket}/${key} exists, not overwriting.  If you want to overwrite a file you must specify overwrite = true in the task.")
+                        return
                     }
                 } else {
                     logger.quiet("S3 Upload ${file} → s3://${bucket}/${key}")

--- a/src/main/groovy/com/fuseanalytics/gradle/s3/S3Plugin.groovy
+++ b/src/main/groovy/com/fuseanalytics/gradle/s3/S3Plugin.groovy
@@ -125,10 +125,6 @@ class S3Upload extends S3Task {
 
                 Transfer transfer = manager.uploadDirectory(bucket, keyPrefix, project.file(sourceDir), true)
 
-                for( Upload u : transfer.getSubTransfers() ) {
-                    u.addProgressListener( new AfterUploadListener( u, project.file(sourceDir), then ) )
-                }
-
                 S3Listener listener = new S3Listener(transfer, logger)
                 transfer.addProgressListener(listener)
                 transfer.waitForCompletion()
@@ -206,10 +202,6 @@ class S3Download extends S3Task {
                 }
                 logger.quiet("S3 Download recursive s3://${bucket}/${keyPrefix} → ${project.file(destDir)}/")
                 transfers = [ manager.downloadDirectory(bucket, keyPrefix, project.file(destDir)) ]
-
-                for( Download u : transfers.first().getSubTransfers() ) {
-                    u.addProgressListener( new AfterDownloadListener( u, project.file(destDir), then ) )
-                }
             }
             // single file download
             else if (key && file) {
@@ -230,9 +222,7 @@ class S3Download extends S3Task {
                     if( key.contains('*') || key.endsWith('/') ) {
                         String prefix = key.replaceAll( /\*$/, '')
                         Transfer t = manager.downloadDirectory(bucket, prefix, project.file(destDir) )
-                        for( Download u : t.getSubTransfers() ) {
-                            u.addProgressListener( new AfterDownloadListener(u, project.file(destDir), then) )
-                        }
+                        return t
                     } else {
                         File output = project.file("${destDir}/${key}")
                         output.parentFile.mkdirs()

--- a/src/main/groovy/com/fuseanalytics/gradle/s3/S3Plugin.groovy
+++ b/src/main/groovy/com/fuseanalytics/gradle/s3/S3Plugin.groovy
@@ -40,7 +40,8 @@ abstract class S3Task extends DefaultTask {
     @Input
     String bucket
 
-    //@Optional
+    @Optional
+    @Internal
     Closure<Void> then
 
     String getBucket() { bucket ?: project.s3.bucket }

--- a/src/main/groovy/com/fuseanalytics/gradle/s3/S3Plugin.groovy
+++ b/src/main/groovy/com/fuseanalytics/gradle/s3/S3Plugin.groovy
@@ -92,6 +92,9 @@ class S3Upload extends S3Task {
 
     @Input
     boolean overwrite = false
+
+    @Input
+    Integer minMultipartUploadThreshold = 100
     
     @TaskAction
     def task() {
@@ -102,7 +105,7 @@ class S3Upload extends S3Task {
 
         TransferManager manager = TransferManagerBuilder.standard()
                 .withS3Client(s3Client)
-                .withMultipartUploadThreshold((long) (100 * 1024 * 1025))
+                .withMultipartUploadThreshold((long) (minMultipartUploadThreshold * 1024 * 1025))
                 .build()
         try {
             // directory upload

--- a/src/main/groovy/com/fuseanalytics/gradle/s3/S3Plugin.groovy
+++ b/src/main/groovy/com/fuseanalytics/gradle/s3/S3Plugin.groovy
@@ -40,7 +40,7 @@ abstract class S3Task extends DefaultTask {
     @Input
     String bucket
 
-    @Optional
+    //@Optional
     Closure<Void> then
 
     String getBucket() { bucket ?: project.s3.bucket }

--- a/src/main/groovy/com/fuseanalytics/gradle/s3/S3Plugin.groovy
+++ b/src/main/groovy/com/fuseanalytics/gradle/s3/S3Plugin.groovy
@@ -236,7 +236,9 @@ class S3Download extends S3Task {
             transfers.each { Transfer transfer ->
                 def listener = new S3Listener(transfer, logger)
                 transfer.addProgressListener(listener)
-                transfer.addProgressListener( new AfterDownloadListener((Download)transfer, project.file(destDir), then) )
+                if( transfer instanceof Download ) {
+                    transfer.addProgressListener( new AfterDownloadListener((Download)transfer, project.file(destDir), then) )
+                }
             }
             transfers.each { Transfer transfer ->
                 transfer.waitForCompletion()

--- a/src/main/groovy/com/fuseanalytics/gradle/s3/S3Plugin.groovy
+++ b/src/main/groovy/com/fuseanalytics/gradle/s3/S3Plugin.groovy
@@ -1,4 +1,4 @@
-package com.mgd.core.gradle
+package com.fuseanalytics.gradle.s3
 
 import com.amazonaws.auth.AWSCredentialsProviderChain
 import com.amazonaws.auth.EC2ContainerCredentialsProviderWrapper


### PR DESCRIPTION
I forked your gradle-s3-plugin several years back to add some features and fix several bugs.  I thought this plugin was abandoned since my original PR's weren't merged.  I now see this plugin was active as Dec 2022 so I thought I'd try once more to combine the plugins.  This PR contains several enhancements and bug fixes.  Here is a summary:

1. Migrated to TransferManager to support uploading and downloading multiple files at once
2. Properly shutting down, waiting for transfers to finish, and reading the buffers fully so that multiple uploads/downloads would work.  keyPrefix transfers would not work without properly waiting for transfers to finish and shutting down properly. 
3. Add support for multipart uploads for larger sized files to successfully transfer (GB+)
4. Added the **keys** property that combines existing properties keys and keyPrefix into a single property that takes an array and can perform both single file download and wildcard downloads into one task.
5. Several defects fixed to enable incremental builds (ie don't download files that have already been downloaded)
6. Logging message to inform the client when an existing key is already uploaded
7. Added a separate callback property **then** which allows you to execute logic after a transfer finished.  There are limitations with multi-transfers that exist because AWS API doesn't support them.