### PR TITLE
Configuring credentials at the task level

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,23 @@ s3 {
 
 Setting the environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` is one way to provide your S3 credentials. See the [AWS Docs](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html) for details on credentials.
 
+Setting system properties is another way that may be useful for managing multiple tasks in the same project with distinct credentials.
+For example, suppose you want distinct tasks for uploading to both a development and production S3 bucket:
+```groovy
+['dev', 'prod'].each { stage ->
+    tasks.register("uploadToS3$stage", S3Upload) {
+        System.setProperty('aws.accessKeyId', project.ext."${stage}KeyId")
+        System.setProperty('aws.secretKey', project.ext."${stage}SecretKey")
+        dependsOn shadowJar
+
+        bucket = "mybucket"
+        key = "myArtifact.jar"
+        file = someBuildTask.archivePath
+        overwrite = true
+    }
+}
+```
+
 ## Amazon EC2 Region
 
 The `s3.region` property can optionally be set to define the Amazon EC2 region if one has not been set in the authentication profile. It can also be used to override the default region set in the AWS credentials provider. 

--- a/src/main/groovy/com/mgd/core/gradle/S3Plugin.groovy
+++ b/src/main/groovy/com/mgd/core/gradle/S3Plugin.groovy
@@ -42,13 +42,21 @@ abstract class S3Task extends DefaultTask {
         return bucket ?: project.s3.bucket
     }
 
+    @Optional
+    @Input
+    String profile
+
+    String getProfile() {
+        return profile ?: project.s3.profile
+    }
+
     @Internal
     AmazonS3 getS3Client() {
 
         ProfileCredentialsProvider profileCreds
-        if (project.s3.profile) {
-            logger.quiet("Using AWS credentials profile: ${project.s3.profile}")
-            profileCreds = new ProfileCredentialsProvider(project.s3.profile)
+        if (profile) {
+            logger.quiet("Using AWS credentials profile: ${profile}")
+            profileCreds = new ProfileCredentialsProvider(profile)
         }
         else {
             profileCreds = new ProfileCredentialsProvider()


### PR DESCRIPTION
These are two suggestions at how to approach the same problem: what if I need multiple tasks in the same project that can upload to different buckets across different accounts, or with different permissions?

One way that occurred to me was to let consumers set the profile at the task level, similar to how they can override the bucket.

Another way was simply to use the System Properties, since the system properties come second in the [chain](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html). As already noted in the README, you can set environment variables outside of Gradle. That gets tricky, though, if you want to execute multiple tasks in the same environment. If someone were using, say, the [Gradle Credentials plugin](https://github.com/etiennestuder/gradle-credentials-plugin) to manage credentials for the different accounts, it occurred to me that system properties might be a handy way to configure individual tasks to use varied credentials.

I expect either approach would work, and maybe both are useful and valid. I'd love to know what you think.