### PR TITLE
Fixed default branch name in Main Actions Workflow

### DIFF
--- a/.github/workflows/main_workflow.yml
+++ b/.github/workflows/main_workflow.yml
@@ -3,7 +3,7 @@ name: Build and Publish
 on:
   push:
     branches:
-      - 'main'
+      - 'master'
 
 env:
   JAVA_VERSION: '17'


### PR DESCRIPTION
- Changed default branch name from `main` to `master` in workflow file.