### PR TITLE
Update Gradle setup GitHub Actions Step

### DIFF
--- a/.github/workflows/main_workflow.yml
+++ b/.github/workflows/main_workflow.yml
@@ -8,7 +8,6 @@ on:
 env:
   JAVA_VERSION: '17'
   JAVA_DISTRIBUTION: 'corretto'
-  GRADLE_VERSION: 8.7
 
 jobs:
   Build:
@@ -32,9 +31,7 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-        with:
-          gradle-version: ${{ env.GRADLE_VERSION }}
+        uses: gradle/actions/setup-gradle@v3
       - name: Gradle Build and Publish
         run: ./gradlew build --stacktrace --debug --scan publish
       - name: Gradle Release Task

--- a/.github/workflows/pr_workflow.yml
+++ b/.github/workflows/pr_workflow.yml
@@ -6,7 +6,6 @@ on:
 env:
   JAVA_VERSION: '17'
   JAVA_DISTRIBUTION: 'corretto'
-  GRADLE_VERSION: 8.7
 
 jobs:
   build:
@@ -26,8 +25,6 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-        with:
-          gradle-version: ${{ env.GRADLE_VERSION }}
+        uses: gradle/actions/setup-gradle@v3
       - name: Gradle Build and Test
         run: ./gradlew build --scan


### PR DESCRIPTION
- Remove hardcoded `GRADLE_VERSION` environment variable, this will enable the Gradle setup step to use the Gradle wrapper's version by default.
- Update Gradle setup step: <https://github.com/gradle/gradle-build-action>